### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ In this exercise, you will:
 
 2. In the new tab, most of the prompts will automatically fill in for you.
    - For owner, choose your personal account or an organization to host the repository.
-   - We recommend creating a public repository, as private repositories will [use Actions minutes](https://docs.github.chttps://github.com/sungwoo106/skills-introduction-to-github/billing/managing-billing-for-github-actions/about-billing-for-github-actions).
+   - We recommend creating a public repository, as private repositories will [use Actions minutes](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions).
    - Scroll down and click the **Create repository** button at the bottom of the form.
 
 3. After your new repository is created, wait about 20 seconds for the exercise to be prepared and buttons updated. You will continue working from your copy of the exercise.


### PR DESCRIPTION
## Summary
- fix the incorrect billing link in README

## Testing
- `grep -n "Actions minutes" -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_6858225f773c83258f32b72d25ea70cc